### PR TITLE
Add @AutoBundleGetter and @AutoBundleSetter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,33 @@ and call internal binding method for each classes.
 
 ### Advanced
 
+#### Getter/Setter
+
+You can use getter/setter for fields. 
+The method named `get/set{keyName}` As a default,
+But you can specify with `@AutoBundleGetter` and `@AutoBundleSetter`.
+
+```java
+@AutoBundleField
+private String userId;
+
+// get{keyName} use as default.
+// no need for @AutoBundleGetter 
+public String getUserId() {
+    return userId;
+}
+
+@AutoBundleGetter(keyName = "userId")
+public String getId() {
+   return userId;
+}
+
+@AutoBundleSetter(keyName = "userId")
+public void setId(String id) {
+   this.userId = id;
+}
+```
+
 #### Set key name
 
 ``key`` is key for ``Bundle``. Default is field name.
@@ -175,7 +202,7 @@ public void onSaveInstanceState(Bundle outState) {
 ``pack(Object object, Bundle bundle)`` stores field value to bundle.
 For example, store in ``onSaveInstanceState`` and restore in ``onCreate``.
 
-For more infomation or usage, see the sample application!
+For more information or usage, see the sample application!
 
 ### Principle
 

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingField.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingField.java
@@ -28,16 +28,22 @@ public class AutoBundleBindingField {
     private final TypeName converter;
     private final boolean hasCustomConverter;
     private final String operationName;
+    private String getterName;
+    private String setterName;
 
     public AutoBundleBindingField(VariableElement element,
                                   AutoBundleField annotation,
                                   Elements elementUtils,
-                                  Types typeUtils) {
+                                  Types typeUtils,
+                                  String getterName,
+                                  String setterName) {
         this.fieldName = element.toString();
         this.argKey = annotation.key().length() > 0 ? annotation.key() : this.fieldName;
         this.required = annotation.required();
         this.argType = TypeName.get(element.asType());
-        Validator.checkAutoBundleFieldModifier(element);
+        this.getterName = getterName;
+        this.setterName = setterName;
+        Validator.checkAutoBundleFieldModifier(element, hasGetter() && hasSetter());
 
         TypeName converter;
         TypeName converted;
@@ -95,6 +101,22 @@ public class AutoBundleBindingField {
 
     public String getOperationName(String operation) {
         return operation + operationName;
+    }
+
+    public String getGetterName() {
+        return getterName;
+    }
+
+    public boolean hasGetter() {
+        return getterName != null && getterName.length() > 0;
+    }
+
+    public String getSetterName() {
+        return setterName;
+    }
+
+    public boolean hasSetter() {
+        return setterName != null && setterName.length() > 0;
     }
 
     public boolean noCast() {

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/BindingDetector.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/BindingDetector.java
@@ -2,6 +2,9 @@ package com.yatatsu.autobundle.processor;
 
 
 import com.yatatsu.autobundle.AutoBundleField;
+import com.yatatsu.autobundle.AutoBundleGetter;
+import com.yatatsu.autobundle.AutoBundleSetter;
+import com.yatatsu.autobundle.processor.exceptions.UnsupportedClassException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -10,6 +13,8 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.Elements;
@@ -43,15 +48,91 @@ final class BindingDetector {
         for (Element enclosedElement : element.getEnclosedElements()) {
             AutoBundleField annotation = enclosedElement.getAnnotation(AutoBundleField.class);
             if (annotation != null) {
-                AutoBundleBindingField field =
-                        new AutoBundleBindingField((VariableElement) enclosedElement,
-                                annotation, elementUtils, typeUtils);
+                VariableElement fieldElement = (VariableElement) enclosedElement;
+                final String getter = findGetterMethod(element, fieldElement, annotation);
+                final String setter = findSetterMethod(element, fieldElement, annotation);
+                AutoBundleBindingField field = new AutoBundleBindingField(
+                        fieldElement, annotation, elementUtils, typeUtils, getter, setter);
                 if (required == field.isRequired()) {
                     fields.add(field);
                 }
             }
         }
         return fields;
+    }
+
+    private static String findGetterMethod(Element classElement,
+                                   VariableElement fieldElement,
+                                   AutoBundleField fieldAnnotation) {
+        final String operation = "get";
+        final String argKeyName = fieldAnnotation.key().length() > 0
+                ? fieldAnnotation.key() : fieldElement.toString();
+        for (Element element : classElement.getEnclosedElements()) {
+            final String methodName = element.getSimpleName().toString();
+            AutoBundleGetter annotation = element.getAnnotation(AutoBundleGetter.class);
+            if (annotation != null) {
+                // annotated getter
+                if (argKeyName.equals(annotation.keyName())) {
+                    // check modifier
+                    if (element.getModifiers().contains(Modifier.PRIVATE)) {
+                        throw new UnsupportedClassException("@AutoBundleGetter must not be private");
+                    }
+                    return methodName;
+                }
+            } else {
+                // default getter
+                if (ElementKind.METHOD == element.getKind() &&
+                        !element.getModifiers().contains(Modifier.PRIVATE) &&
+                        element.getSimpleName().toString().startsWith(operation)) {
+                    if (methodName.equals(
+                            createOperationMethod(operation, argKeyName))) {
+                        int methodModifierLevel = ModifierHelper.getModifierLevel(element);
+                        int fieldModifierLevel = ModifierHelper.getModifierLevel(fieldElement);
+                        if (methodModifierLevel - fieldModifierLevel >= 0) {
+                            return methodName;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String findSetterMethod(Element classElement,
+                                           VariableElement fieldElement,
+                                           AutoBundleField fieldAnnotation) {
+        final String operation = "set";
+        final String argKeyName = fieldAnnotation.key().length() > 0
+                ? fieldAnnotation.key() : fieldElement.toString();
+        for (Element element : classElement.getEnclosedElements()) {
+            final String methodName = element.getSimpleName().toString();
+            AutoBundleSetter annotation = element.getAnnotation(AutoBundleSetter.class);
+            if (annotation != null) {
+                // annotated setter
+                if (argKeyName.equals(annotation.keyName())) {
+                    // check modifier
+                    if (element.getModifiers().contains(Modifier.PRIVATE)) {
+                        throw new UnsupportedClassException("@AutoBundleSetter must not be private");
+                    }
+                    return methodName;
+                }
+            } else {
+                // default setter
+                if (ElementKind.METHOD == element.getKind() &&
+                        !element.getModifiers().contains(Modifier.PRIVATE) &&
+                        element.getSimpleName().toString().startsWith(operation)) {
+                    if (methodName.equals(
+                            createOperationMethod(operation, argKeyName))) {
+                        int methodModifierLevel = ModifierHelper.getModifierLevel(element);
+                        int fieldModifierLevel = ModifierHelper.getModifierLevel(fieldElement);
+                        if (methodModifierLevel - fieldModifierLevel >= 0) {
+                            return methodName;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     static String getPackageName(Elements elementsUtils, TypeElement type) {
@@ -61,6 +142,11 @@ final class BindingDetector {
     static String getClassName(TypeElement type, String packageName) {
         int packageLen = packageName.length() + 1;
         return type.getQualifiedName().toString().substring(packageLen).replace('.', '$');
+    }
+
+    private static String createOperationMethod(String operation, String keyName) {
+        String capitalized = Character.toUpperCase(keyName.charAt(0)) + keyName.substring(1);
+        return operation + capitalized;
     }
 
     private BindingDetector() {

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/ModifierHelper.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/ModifierHelper.java
@@ -1,0 +1,28 @@
+package com.yatatsu.autobundle.processor;
+
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+
+
+public class ModifierHelper {
+    static final int PRIVATE   = -1;
+    static final int DEFAULT   = 0;
+    static final int PROTECTED = 1;
+    static final int PUBLIC    = 2;
+
+    static int getModifierLevel(Element element) {
+        Set<Modifier> modifiers = element.getModifiers();
+        if (modifiers.contains(Modifier.PUBLIC)) {
+            return PUBLIC;
+        }
+        if (modifiers.contains(Modifier.PROTECTED)) {
+            return PROTECTED;
+        }
+        if (modifiers.contains(Modifier.PRIVATE)) {
+            return PRIVATE;
+        }
+        return DEFAULT;
+    }
+}

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/Validator.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/Validator.java
@@ -54,12 +54,11 @@ final class Validator {
         }
     }
 
-    static void checkAutoBundleFieldModifier(VariableElement element) {
+    static void checkAutoBundleFieldModifier(VariableElement element, boolean hasGetterSetter) {
         Set<Modifier> modifiers = element.getModifiers();
-        if (modifiers.contains(Modifier.PRIVATE) ||
-                modifiers.contains(Modifier.PROTECTED)) {
+        if (modifiers.contains(Modifier.PRIVATE) && !hasGetterSetter) {
             throw new IllegalStateException(
-                    AutoBundleField.class + " must not be with private/protected class.");
+                    AutoBundleField.class + " does not support private field without setter/getter.");
         }
     }
 

--- a/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/AutoBundleProcessorTest.java
+++ b/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/AutoBundleProcessorTest.java
@@ -8,6 +8,9 @@ import com.yatatsu.autobundle.processor.data.DuplicateKey;
 import com.yatatsu.autobundle.processor.data.NotEmptyConstructorConverter;
 import com.yatatsu.autobundle.processor.data.NotPublicConstructorConverter;
 import com.yatatsu.autobundle.processor.data.NotSupportedFieldType;
+import com.yatatsu.autobundle.processor.data.PrivateAnnotatedGetter;
+import com.yatatsu.autobundle.processor.data.PrivateAnnotatedSetter;
+import com.yatatsu.autobundle.processor.data.PrivateFieldWithoutGetterSetter;
 import com.yatatsu.autobundle.processor.data.SourceBase;
 import com.yatatsu.autobundle.processor.data.ValidFragment;
 import com.yatatsu.autobundle.processor.data.WrongSuperClass;
@@ -77,6 +80,27 @@ public class AutoBundleProcessorTest {
         expectedException.expectMessage("AutoBundle target class must be subtype of" +
                 " 'Fragment', 'Activity', 'Receiver' or 'Service'.");
         assertGenerateCode(new WrongSuperClass());
+    }
+
+    @Test
+    public void testPrivateAnnotatedGetter() {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("@AutoBundleGetter must not be private");
+        assertGenerateCode(new PrivateAnnotatedGetter());
+    }
+
+    @Test
+    public void testPrivateAnnotatedSetter() {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("@AutoBundleSetter must not be private");
+        assertGenerateCode(new PrivateAnnotatedSetter());
+    }
+
+    @Test
+    public void testPrivateFieldWithoutGetterAndSetter() {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage(" does not support private field without setter/getter.");
+        assertGenerateCode(new PrivateFieldWithoutGetterSetter());
     }
 
     @Test

--- a/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/NotSupportedFieldType.java
+++ b/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/NotSupportedFieldType.java
@@ -1,8 +1,6 @@
 package com.yatatsu.autobundle.processor.data;
 
-/**
-* Created by kitagawatatsuya on 2015/09/23.
-*/
+
 public class NotSupportedFieldType implements SourceBase {
 
         @Override

--- a/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/PrivateAnnotatedGetter.java
+++ b/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/PrivateAnnotatedGetter.java
@@ -1,0 +1,41 @@
+package com.yatatsu.autobundle.processor.data;
+
+
+public class PrivateAnnotatedGetter implements SourceBase {
+    @Override
+    public String getTargetClassName() {
+        return "com.yatatsu.autobundle.example.ExampleActivity";
+    }
+
+    @Override
+    public String getTargetSource() {
+        return "package com.yatatsu.autobundle.example;\n" +
+                "\n" +
+                "import android.app.Activity;\n" +
+                "\n" +
+                "import com.yatatsu.autobundle.AutoBundleField;\n" +
+                "import com.yatatsu.autobundle.AutoBundleGetter;\n" +
+                "\n" +
+                "\n" +
+                "public class ExampleActivity extends Activity {\n" +
+                "\n" +
+                "@AutoBundleField(key = \"itemName\")\n" +
+                "private String name;\n" +
+                "\n" +
+                "@AutoBundleGetter(keyName = \"itemName\")\n" +
+                "private String getName() {\n" +
+                "return name;\n" +
+                "}\n" +
+                "}";
+    }
+
+    @Override
+    public String getExpectClassName() {
+        return "";
+    }
+
+    @Override
+    public String getExpectSource() {
+        return "";
+    }
+}

--- a/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/PrivateAnnotatedSetter.java
+++ b/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/PrivateAnnotatedSetter.java
@@ -1,0 +1,41 @@
+package com.yatatsu.autobundle.processor.data;
+
+
+public class PrivateAnnotatedSetter implements SourceBase {
+    @Override
+    public String getTargetClassName() {
+        return "com.yatatsu.autobundle.example.ExampleActivity";
+    }
+
+    @Override
+    public String getTargetSource() {
+        return "package com.yatatsu.autobundle.example;\n" +
+                "\n" +
+                "import android.app.Activity;\n" +
+                "\n" +
+                "import com.yatatsu.autobundle.AutoBundleField;\n" +
+                "import com.yatatsu.autobundle.AutoBundleSetter;\n" +
+                "\n" +
+                "\n" +
+                "public class ExampleActivity extends Activity {\n" +
+                "\n" +
+                "@AutoBundleField(key = \"itemName\")\n" +
+                "private String name;\n" +
+                "\n" +
+                "@AutoBundleSetter(keyName = \"itemName\")\n" +
+                "private void setName(String name) {\n" +
+                "this.name = name; \n" +
+                "}\n" +
+                "}\n";
+    }
+
+    @Override
+    public String getExpectClassName() {
+        return "";
+    }
+
+    @Override
+    public String getExpectSource() {
+        return "";
+    }
+}

--- a/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/PrivateFieldWithoutGetterSetter.java
+++ b/autobundle-processor/src/test/java/com/yatatsu/autobundle/processor/data/PrivateFieldWithoutGetterSetter.java
@@ -1,0 +1,35 @@
+package com.yatatsu.autobundle.processor.data;
+
+
+public class PrivateFieldWithoutGetterSetter implements SourceBase {
+    @Override
+    public String getTargetClassName() {
+        return "com.yatatsu.autobundle.example.ExampleActivity";
+    }
+
+    @Override
+    public String getTargetSource() {
+        return "package com.yatatsu.autobundle.example;\n" +
+                "\n" +
+                "import android.app.Activity;\n" +
+                "\n" +
+                "import com.yatatsu.autobundle.AutoBundleField;\n" +
+                "\n" +
+                "public class ExampleActivity extends Activity {\n" +
+                "\n" +
+                "@AutoBundleField(key = \"itemName\")\n" +
+                "private String name;\n" +
+                "\n" +
+                "}\n";
+    }
+
+    @Override
+    public String getExpectClassName() {
+        return "";
+    }
+
+    @Override
+    public String getExpectSource() {
+        return "";
+    }
+}

--- a/autobundle/src/main/java/com/yatatsu/autobundle/AutoBundleGetter.java
+++ b/autobundle/src/main/java/com/yatatsu/autobundle/AutoBundleGetter.java
@@ -1,0 +1,12 @@
+package com.yatatsu.autobundle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface AutoBundleGetter {
+    String keyName();
+}

--- a/autobundle/src/main/java/com/yatatsu/autobundle/AutoBundleSetter.java
+++ b/autobundle/src/main/java/com/yatatsu/autobundle/AutoBundleSetter.java
@@ -1,0 +1,12 @@
+package com.yatatsu.autobundle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface AutoBundleSetter {
+    String keyName();
+}

--- a/example/src/main/java/com/yatatsu/autobundle/example/ExampleActivity.java
+++ b/example/src/main/java/com/yatatsu/autobundle/example/ExampleActivity.java
@@ -8,6 +8,8 @@ import android.widget.TextView;
 
 import com.yatatsu.autobundle.AutoBundle;
 import com.yatatsu.autobundle.AutoBundleField;
+import com.yatatsu.autobundle.AutoBundleGetter;
+import com.yatatsu.autobundle.AutoBundleSetter;
 
 import java.util.ArrayList;
 
@@ -28,6 +30,24 @@ public class ExampleActivity extends AppCompatActivity {
 
     @AutoBundleField(required = false)
     ArrayList<Person> persons;
+
+    String getName() {
+        return name;
+    }
+
+    void setName(String name) {
+        this.name = name;
+    }
+
+    @AutoBundleSetter(keyName = "optionalName")
+    protected void setAltName(String name) {
+        this.optionalName = name;
+    }
+
+    @AutoBundleGetter(keyName = "optionalName")
+    public String getAltName() {
+        return optionalName;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
## Rule for Getter/Setter
1. If a method named `get/set{keyName}` without private modifier exist, use it as default.
2. If a method annotated with `@AutoBundleGetter/Setter` exist, use it respectively.
3. If a annotated method has private modifier, throw a exception.
4. If a annotated field has private modifier without getter/setter, throw a exception.
