### PR TITLE
nullable nonnull support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.1
+    - build-tools-25.0.2
     - android-25
     - extra-android-m2repository
     - extra-android-support

--- a/autobundle-processor/build.gradle
+++ b/autobundle-processor/build.gradle
@@ -15,8 +15,10 @@ dependencies {
     compile 'com.squareup:javapoet:1.8.0'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'com.google.android:android:4.1.1.4'
     testCompile 'com.google.android:support-v4:r7'
+    testCompile rootProject.ext.androidJar
+    testCompile "com.android.support:support-v4:${supportLibraryVersion}"
+    testCompile "com.android.support:support-annotations:${supportLibraryVersion}"
     testCompile 'com.google.testing.compile:compile-testing:0.10'
 }
 

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBinderWriter.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBinderWriter.java
@@ -1,9 +1,11 @@
 package com.yatatsu.autobundle.processor;
 
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 
@@ -13,7 +15,7 @@ import java.util.List;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Modifier;
 
-public class AutoBundleBinderWriter {
+class AutoBundleBinderWriter {
 
   private final List<AutoBundleBindingClass> bindingClasses;
   private static final String TARGET_CLASS_NAME = "AutoBundleBindingDispatcher";
@@ -21,48 +23,55 @@ public class AutoBundleBinderWriter {
   private static final ClassName CLASS_BUNDLE = ClassName.get("android.os", "Bundle");
   private static final ClassName CLASS_INTENT = ClassName.get("android.content", "Intent");
 
-  public AutoBundleBinderWriter(List<AutoBundleBindingClass> bindingClasses) {
+  private static final AnnotationSpec ANNOTATION_NONNULL
+          = AnnotationSpec.builder(ClassName.get("android.support.annotation", "NonNull")).build();
+
+  AutoBundleBinderWriter(List<AutoBundleBindingClass> bindingClasses) {
     this.bindingClasses = bindingClasses;
   }
 
-  public void write(Filer filer) throws IOException {
+  void write(Filer filer) throws IOException {
     TypeSpec clazz = TypeSpec.classBuilder(TARGET_CLASS_NAME)
-        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-        .addMethod(createBindWithArgsMethod(bindingClasses))
-        .addMethod(createBindWithIntentMethod(bindingClasses))
-        .addMethod(createBindFragmentMethod(bindingClasses))
-        .addMethod(createPackMethod(bindingClasses))
-        .build();
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(createBindWithArgsMethod(bindingClasses))
+            .addMethod(createBindWithIntentMethod(bindingClasses))
+            .addMethod(createBindFragmentMethod(bindingClasses))
+            .addMethod(createPackMethod(bindingClasses))
+            .build();
     JavaFile.builder(TARGET_PACKAGE_NAME, clazz)
-        .build()
-        .writeTo(filer);
+            .build()
+            .writeTo(filer);
   }
 
   private static MethodSpec createBindWithArgsMethod(List<AutoBundleBindingClass> classes) {
     MethodSpec.Builder builder = MethodSpec.methodBuilder("bind")
-        .addModifiers(Modifier.PUBLIC)
-        .addParameter(Object.class, "target")
-        .addParameter(CLASS_BUNDLE, "args")
-        .returns(void.class);
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(ParameterSpec.builder(Object.class, "target")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .addParameter(ParameterSpec.builder(CLASS_BUNDLE, "args")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .returns(void.class);
 
     for (AutoBundleBindingClass bindingClass : classes) {
       TypeName type = bindingClass.getTargetType();
       ClassName bindClassType =
-          ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
+              ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
       builder.beginControlFlow("if (target instanceof $T)", type)
-          .addStatement("$T.bind(($T)target, args)", bindClassType, type)
-          .addStatement("return")
-          .endControlFlow();
+              .addStatement("$T.bind(($T)target, args)", bindClassType, type)
+              .addStatement("return")
+              .endControlFlow();
     }
     return builder.build();
   }
 
   private static MethodSpec createBindWithIntentMethod(List<AutoBundleBindingClass> classes) {
     MethodSpec.Builder builder = MethodSpec.methodBuilder("bind")
-        .addModifiers(Modifier.PUBLIC)
-        .addParameter(Object.class, "target")
-        .addParameter(CLASS_INTENT, "intent")
-        .returns(void.class);
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(ParameterSpec.builder(Object.class, "target")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .addParameter(ParameterSpec.builder(CLASS_INTENT, "intent")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .returns(void.class);
 
     for (AutoBundleBindingClass bindingClass : classes) {
       if (bindingClass.getBuilderType() != AutoBundleBindingClass.BuilderType.Intent) {
@@ -70,20 +79,21 @@ public class AutoBundleBinderWriter {
       }
       TypeName type = bindingClass.getTargetType();
       ClassName bindClassType =
-          ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
+              ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
       builder.beginControlFlow("if (target instanceof $T)", type)
-          .addStatement("$T.bind(($T)target, intent)", bindClassType, type)
-          .addStatement("return")
-          .endControlFlow();
+              .addStatement("$T.bind(($T)target, intent)", bindClassType, type)
+              .addStatement("return")
+              .endControlFlow();
     }
     return builder.build();
   }
 
   private static MethodSpec createBindFragmentMethod(List<AutoBundleBindingClass> classes) {
     MethodSpec.Builder builder = MethodSpec.methodBuilder("bind")
-        .addModifiers(Modifier.PUBLIC)
-        .addParameter(Object.class, "target")
-        .returns(void.class);
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(ParameterSpec.builder(Object.class, "target")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .returns(void.class);
 
     for (AutoBundleBindingClass bindingClass : classes) {
       if (bindingClass.getBuilderType() != AutoBundleBindingClass.BuilderType.Fragment) {
@@ -91,30 +101,32 @@ public class AutoBundleBinderWriter {
       }
       TypeName type = bindingClass.getTargetType();
       ClassName bindClassType =
-          ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
+              ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
       builder.beginControlFlow("if (target instanceof $T)", type)
-          .addStatement("$T.bind(($T)target)", bindClassType, type)
-          .addStatement("return")
-          .endControlFlow();
+              .addStatement("$T.bind(($T)target)", bindClassType, type)
+              .addStatement("return")
+              .endControlFlow();
     }
     return builder.build();
   }
 
   private static MethodSpec createPackMethod(List<AutoBundleBindingClass> classes) {
     MethodSpec.Builder builder = MethodSpec.methodBuilder("pack")
-        .addModifiers(Modifier.PUBLIC)
-        .addParameter(Object.class, "target")
-        .addParameter(CLASS_BUNDLE, "args")
-        .returns(void.class);
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(ParameterSpec.builder(Object.class, "target")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .addParameter(ParameterSpec.builder(CLASS_BUNDLE, "args")
+                    .addAnnotation(ANNOTATION_NONNULL).build())
+            .returns(void.class);
 
     for (AutoBundleBindingClass bindingClass : classes) {
       TypeName type = bindingClass.getTargetType();
       ClassName bindClassType =
-          ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
+              ClassName.get(bindingClass.getPackageName(), bindingClass.getHelperClassName());
       builder.beginControlFlow("if (target instanceof $T)", type)
-          .addStatement("$T.pack(($T)target, args)", bindClassType, type)
-          .addStatement("return")
-          .endControlFlow();
+              .addStatement("$T.pack(($T)target, args)", bindClassType, type)
+              .addStatement("return")
+              .endControlFlow();
     }
     return builder.build();
   }

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingClass.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingClass.java
@@ -12,14 +12,14 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 
-public class AutoBundleBindingClass {
+class AutoBundleBindingClass {
     private static final String FRAGMENT = "android.app.Fragment";
     private static final String SUPPORT_FRAGMENT = "android.support.v4.app.Fragment";
     private static final String ACTIVITY = "android.app.Activity";
     private static final String BROADCAST_RECEIVER = "android.content.BroadcastReceiver";
     private static final String SERVICE = "android.app.Service";
 
-    public enum BuilderType {
+    enum BuilderType {
         Intent, Fragment, None;
 
         public static BuilderType byTypeName(Element element,
@@ -55,9 +55,9 @@ public class AutoBundleBindingClass {
     private final List<AutoBundleBindingField> requiredArgs;
     private final List<AutoBundleBindingField> notRequiredArgs;
 
-    public AutoBundleBindingClass(TypeElement typeElement,
-                                  Elements elementsUtils,
-                                  Types typeUtils) {
+    AutoBundleBindingClass(TypeElement typeElement,
+                           Elements elementsUtils,
+                           Types typeUtils) {
         this.targetType = ClassName.get(typeElement);
         Validator.checkAutoBundleTargetModifier(typeElement);
         this.packageName = BindingDetector.getPackageName(elementsUtils, typeElement);
@@ -74,31 +74,31 @@ public class AutoBundleBindingClass {
         Validator.checkDuplicatedArgsKey(args);
     }
 
-    public ClassName getTargetType() {
+    ClassName getTargetType() {
         return targetType;
     }
 
-    public String getPackageName() {
+    String getPackageName() {
         return packageName;
     }
 
-    public BuilderType getBuilderType() {
+    BuilderType getBuilderType() {
         return builderType;
     }
 
-    public List<AutoBundleBindingField> getRequiredArgs() {
+    List<AutoBundleBindingField> getRequiredArgs() {
         return requiredArgs;
     }
 
-    public List<AutoBundleBindingField> getNotRequiredArgs() {
+    List<AutoBundleBindingField> getNotRequiredArgs() {
         return notRequiredArgs;
     }
 
-    public String getBuilderClassName() {
+    String getBuilderClassName() {
         return builderType.name() + "Builder";
     }
 
-    public String getHelperClassName() {
+    String getHelperClassName() {
         return className + "AutoBundle";
     }
 }

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingField.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingField.java
@@ -19,7 +19,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 
-public class AutoBundleBindingField {
+class AutoBundleBindingField {
 
     private final String fieldName;
     private final String argKey;
@@ -32,12 +32,12 @@ public class AutoBundleBindingField {
     private final String setterName;
     private final List<ClassName> annotations;
 
-    public AutoBundleBindingField(VariableElement element,
-                                  AutoBundleField annotation,
-                                  Elements elementUtils,
-                                  Types typeUtils,
-                                  String getterName,
-                                  String setterName) {
+    AutoBundleBindingField(VariableElement element,
+                           AutoBundleField annotation,
+                           Elements elementUtils,
+                           Types typeUtils,
+                           String getterName,
+                           String setterName) {
         this.fieldName = element.toString();
         this.argKey = annotation.key().length() > 0 ? annotation.key() : this.fieldName;
         this.required = annotation.required();
@@ -77,65 +77,65 @@ public class AutoBundleBindingField {
         }
     }
 
-    public TypeName getArgType() {
+    TypeName getArgType() {
         return argType;
     }
 
-    public String getFieldName() {
+    String getFieldName() {
         return fieldName;
     }
 
-    public String getArgKey() {
+    String getArgKey() {
         return argKey;
     }
 
-    public boolean isRequired() {
+    boolean isRequired() {
         return required;
     }
 
-    public TypeName getConverter() {
+    TypeName getConverter() {
         return converter;
     }
 
-    public boolean hasCustomConverter() {
+    boolean hasCustomConverter() {
         return hasCustomConverter;
     }
 
-    public String getOperationName(String operation) {
+    String getOperationName(String operation) {
         return operation + operationName;
     }
 
-    public String getGetterName() {
+    String getGetterName() {
         return getterName;
     }
 
-    public boolean hasGetter() {
+    boolean hasGetter() {
         return getterName != null && getterName.length() > 0;
     }
 
-    public String getSetterName() {
+    String getSetterName() {
         return setterName;
     }
 
-    public boolean hasSetter() {
+    boolean hasSetter() {
         return setterName != null && setterName.length() > 0;
     }
 
-    public boolean noCast() {
+    boolean noCast() {
         return operationName.equals("ParcelableArrayList") ||
                 operationName.equals("ParcelableArray") ||
                 operationName.equals("SparseParcelableArray");
     }
 
-    public List<ClassName> getAnnotations() {
+    List<ClassName> getAnnotations() {
         return annotations;
     }
 
-    public boolean hasAnnotations() {
+    boolean hasAnnotations() {
         return !annotations.isEmpty();
     }
 
-    static TypeName detectConvertedTypeByTypeElement(TypeElement element) {
+    private static TypeName detectConvertedTypeByTypeElement(TypeElement element) {
         TypeMirror typeMirror = getConverterGenericsTypesByTypeElement(element).get(1);
         TypeName typeName = TypeName.get(typeMirror);
         try {
@@ -144,7 +144,7 @@ public class AutoBundleBindingField {
         return typeName;
     }
 
-    static List<? extends TypeMirror> getConverterGenericsTypesByTypeElement(TypeElement element) {
+    private static List<? extends TypeMirror> getConverterGenericsTypesByTypeElement(TypeElement element) {
         TypeElement targetType = element;
         while (targetType != null) {
             if (!targetType.getInterfaces().isEmpty()) {
@@ -167,7 +167,7 @@ public class AutoBundleBindingField {
         throw new UnsupportedOperationException("Not found convert type: " + element.toString());
     }
 
-    static TypeName detectConvertedTypeNameByClass(Class clazz) {
+    private static TypeName detectConvertedTypeNameByClass(Class clazz) {
         Type converted = getConverterGenericsTypesByClass(clazz)[1];
         TypeName typeName = TypeName.get(converted);
         try {
@@ -176,7 +176,7 @@ public class AutoBundleBindingField {
         return typeName;
     }
 
-    static Type[] getConverterGenericsTypesByClass(Class clazz) {
+    private static Type[] getConverterGenericsTypesByClass(Class clazz) {
         Type type = AutoBundleConverter.class;
         Class targetClass = clazz;
         while (targetClass != null) {

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingField.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleBindingField.java
@@ -40,7 +40,8 @@ class AutoBundleBindingField {
                            String setterName) {
         this.fieldName = element.toString();
         this.argKey = annotation.key().length() > 0 ? annotation.key() : this.fieldName;
-        this.required = annotation.required();
+        // @Nullable makes `required` to false
+        this.required = annotation.required() && !BindingFieldHelper.hasNullableAnnotation(element);
         this.argType = TypeName.get(element.asType());
         this.getterName = getterName;
         this.setterName = setterName;

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleWriter.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleWriter.java
@@ -1,5 +1,6 @@
 package com.yatatsu.autobundle.processor;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
@@ -16,18 +17,25 @@ import javax.annotation.processing.Filer;
 import javax.lang.model.element.Modifier;
 
 
-public class AutoBundleWriter {
+class AutoBundleWriter {
 
     private final AutoBundleBindingClass bindingClass;
 
     private static final String FIELD_BUNDLE_NAME = "args";
     private static final ClassName CLASS_BUNDLE = ClassName.get("android.os", "Bundle");
+    private static final ClassName CLASS_CONTEXT = ClassName.get("android.content", "Context");
+    private static final ClassName CLASS_INTENT = ClassName.get("android.content", "Intent");
 
-    public AutoBundleWriter(AutoBundleBindingClass target) {
+    private static final AnnotationSpec ANNOTATION_NONNULL
+            = AnnotationSpec.builder(ClassName.get("android.support.annotation", "NonNull")).build();
+    private static final AnnotationSpec ANNOTATION_NULLABLE
+            = AnnotationSpec.builder(ClassName.get("android.support.annotation", "Nullable")).build();
+
+    AutoBundleWriter(AutoBundleBindingClass target) {
         this.bindingClass = target;
     }
 
-    public void write(Filer filer) throws IOException {
+    void write(Filer filer) throws IOException {
         TypeSpec clazz = TypeSpec.classBuilder(bindingClass.getHelperClassName())
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addType(createBuilderClass(bindingClass))
@@ -50,19 +58,23 @@ public class AutoBundleWriter {
         MethodSpec.Builder builder =
                 MethodSpec.methodBuilder("create" + target.getBuilderType().name() + "Builder")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(builderClass)
+                .returns(builderClass.annotated(ANNOTATION_NONNULL))
                 .addCode("return new $T(", builderClass);
         for (int i = 0, count = target.getRequiredArgs().size(); i < count; i++) {
-            if (i > 0) {
-                builder.addCode(",");
-            }
             AutoBundleBindingField arg = target.getRequiredArgs().get(i);
             ParameterSpec.Builder paramBuilder = ParameterSpec.builder(arg.getArgType(),
                     arg.getArgKey());
+            // annotations
             if (arg.hasAnnotations()) {
-                for (ClassName annotation : arg.getAnnotations()) {
-                    paramBuilder.addAnnotation(annotation);
-                }
+                arg.getAnnotations().forEach(paramBuilder::addAnnotation);
+            }
+            // nonnull
+            if (!arg.getArgType().isPrimitive()) {
+                paramBuilder.addAnnotation(ANNOTATION_NONNULL);
+            }
+            // statement
+            if (i > 0) {
+                builder.addCode(", ");
             }
             builder.addParameter(paramBuilder.build())
                     .addCode("$N", arg.getArgKey());
@@ -89,14 +101,20 @@ public class AutoBundleWriter {
         for (AutoBundleBindingField arg : target.getRequiredArgs()) {
             String key = arg.getArgKey();
             TypeName type = arg.getArgType();
-            String operationName = arg.getOperationName("put");
+            // parameter for constructor
+            // support annotation
             ParameterSpec.Builder paramBuilder = ParameterSpec.builder(type, key);
             if (arg.hasAnnotations()) {
-                for (ClassName annotation : arg.getAnnotations()) {
-                    paramBuilder.addAnnotation(annotation);
-                }
+                arg.getAnnotations().forEach(paramBuilder::addAnnotation);
+            }
+            // nonnull
+            if (!type.isPrimitive()) {
+                paramBuilder.addAnnotation(ANNOTATION_NONNULL);
             }
             builder.addParameter(paramBuilder.build());
+
+            // statement
+            String operationName = arg.getOperationName("put");
             if (arg.hasCustomConverter()) {
                 TypeName converter = arg.getConverter();
                 builder.addStatement("$T $NConverter = new $T()", converter, key, converter)
@@ -124,17 +142,18 @@ public class AutoBundleWriter {
 
             ParameterSpec.Builder paramBuilder = ParameterSpec.builder(argType, argKey);
             if (arg.hasAnnotations()) {
-                for (ClassName annotation : arg.getAnnotations()) {
-                    paramBuilder.addAnnotation(annotation);
-                }
+                arg.getAnnotations().forEach(paramBuilder::addAnnotation);
+            }
+            final boolean nullable = !argType.isPrimitive();
+            if (nullable) {
+                paramBuilder.addAnnotation(ANNOTATION_NULLABLE);
             }
             MethodSpec.Builder builder = MethodSpec.methodBuilder(argKey)
                     .addModifiers(Modifier.PUBLIC)
                     .addParameter(paramBuilder.build())
-                    .returns(getBuilderClassName(target));
+                    .returns(getBuilderClassName(target).annotated(ANNOTATION_NONNULL));
 
-            final boolean checkNull = !arg.getArgType().isPrimitive();
-            if (checkNull) {
+            if (nullable) {
                 builder.beginControlFlow("if ($N != null)", argKey);
             }
             if (arg.hasCustomConverter()) {
@@ -145,7 +164,7 @@ public class AutoBundleWriter {
             } else {
                 builder.addStatement("$N.$N($S, $N)", fieldName, operationName, argKey, argKey);
             }
-            if (checkNull) {
+            if (nullable) {
                 builder.endControlFlow();
             }
 
@@ -170,15 +189,16 @@ public class AutoBundleWriter {
         ClassName targetClass = target.getTargetType();
         MethodSpec buildWithNoParam = MethodSpec.methodBuilder("build")
                 .addModifiers(Modifier.PUBLIC)
-                .returns(targetClass)
+                .returns(targetClass.annotated(ANNOTATION_NONNULL))
                 .addStatement("$T fragment = new $T()", targetClass, targetClass)
                 .addStatement("fragment.setArguments($N)", fieldName)
                 .addStatement("return fragment")
                 .build();
         MethodSpec buildWithFragment = MethodSpec.methodBuilder("build")
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(targetClass, "fragment")
-                .returns(targetClass)
+                .addParameter(ParameterSpec.builder(targetClass, "fragment")
+                        .addAnnotation(ANNOTATION_NONNULL).build())
+                .returns(targetClass.annotated(ANNOTATION_NONNULL))
                 .addStatement("fragment.setArguments($N)", fieldName)
                 .addStatement("return fragment")
                 .build();
@@ -190,21 +210,21 @@ public class AutoBundleWriter {
     private static List<MethodSpec> createIntentBuildMethods(AutoBundleBindingClass target,
                                                              String fieldName) {
         List<MethodSpec> methodSpecs = new ArrayList<>(2);
-        ClassName contextClass = ClassName.get("android.content", "Context");
-        ClassName intentClass = ClassName.get("android.content", "Intent");
         MethodSpec buildWithContext = MethodSpec.methodBuilder("build")
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(contextClass, "context")
-                .returns(intentClass)
+                .addParameter(ParameterSpec.builder(CLASS_CONTEXT, "context")
+                        .addAnnotation(ANNOTATION_NONNULL).build())
+                .returns(CLASS_INTENT.annotated(ANNOTATION_NONNULL))
                 .addStatement("$T intent = new $T(context, $T.class)",
-                        intentClass, intentClass, target.getTargetType())
+                        CLASS_INTENT, CLASS_INTENT, target.getTargetType())
                 .addStatement("intent.putExtras($N)", fieldName)
                 .addStatement("return intent")
                 .build();
         MethodSpec buildWithIntent = MethodSpec.methodBuilder("build")
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(intentClass, "intent")
-                .returns(intentClass)
+                .addParameter(ParameterSpec.builder(CLASS_INTENT, "intent")
+                        .addAnnotation(ANNOTATION_NONNULL).build())
+                .returns(CLASS_INTENT.annotated(ANNOTATION_NONNULL))
                 .addStatement("intent.putExtras($N)", fieldName)
                 .addStatement("return intent")
                 .build();
@@ -221,8 +241,12 @@ public class AutoBundleWriter {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("bind")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(void.class)
-                .addParameter(target.getTargetType(), "target")
-                .addParameter(CLASS_BUNDLE, "source");
+                .addParameter(
+                        ParameterSpec.builder(target.getTargetType(), "target")
+                                .addAnnotation(ANNOTATION_NONNULL).build())
+                .addParameter(
+                        ParameterSpec.builder(CLASS_BUNDLE, "source")
+                                .addAnnotation(ANNOTATION_NONNULL).build());
 
         for (AutoBundleBindingField arg : args) {
             String key = arg.getArgKey();
@@ -276,14 +300,20 @@ public class AutoBundleWriter {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("bind")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(void.class)
-                .addParameter(target.getTargetType(), "target");
+                .addParameter(
+                        ParameterSpec.builder(target.getTargetType(), "target")
+                                .addAnnotation(ANNOTATION_NONNULL).build());
 
         switch (target.getBuilderType()) {
             case Fragment:
-                builder.addStatement("bind(target, target.getArguments())");
+                builder.beginControlFlow("if (target.getArguments() != null)")
+                        .addStatement("bind(target, target.getArguments())")
+                        .endControlFlow();
                 break;
             case Intent:
-                builder.addParameter(ClassName.get("android.content", "Intent"), "intent");
+                builder.addParameter(
+                        ParameterSpec.builder(CLASS_INTENT, "intent")
+                                .addAnnotation(ANNOTATION_NONNULL).build());
                 builder.beginControlFlow("if (intent.getExtras() != null)")
                         .addStatement("bind(target, intent.getExtras())")
                         .endControlFlow();
@@ -300,8 +330,12 @@ public class AutoBundleWriter {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("pack")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(void.class)
-                .addParameter(target.getTargetType(), "source")
-                .addParameter(CLASS_BUNDLE, "args");
+                .addParameter(
+                        ParameterSpec.builder(target.getTargetType(), "source")
+                                .addAnnotation(ANNOTATION_NONNULL).build())
+                .addParameter(
+                        ParameterSpec.builder(CLASS_BUNDLE, "args")
+                                .addAnnotation(ANNOTATION_NONNULL).build());
 
         for (AutoBundleBindingField arg : args) {
             String fieldName = arg.getFieldName();

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/BindingFieldHelper.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/BindingFieldHelper.java
@@ -147,6 +147,12 @@ class BindingFieldHelper {
         return null;
     }
 
+    static boolean hasNullableAnnotation(Element fieldElement) {
+        return fieldElement.getAnnotationMirrors().stream()
+                .map(am -> am.getAnnotationType().asElement())
+                .anyMatch(e -> e.getSimpleName().toString().equals("Nullable"));
+    }
+
     static List<ClassName> getAnnotationsForField(Element fieldElement) {
         return fieldElement.getAnnotationMirrors().stream()
                 .map(am -> am.getAnnotationType().asElement())

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/BindingFieldHelper.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/BindingFieldHelper.java
@@ -79,6 +79,12 @@ class BindingFieldHelper {
         if (fieldTypes.containsKey(target)) {
             return fieldTypes.get(target);
         }
+        if (target.isBoxedPrimitive()) {
+            TypeName unboxed = target.unbox();
+            if (fieldTypes.containsKey(unboxed)) {
+                return fieldTypes.get(unboxed);
+            }
+        }
 
         // Array
         TypeMirror parcelable = elements.getTypeElement("android.os.Parcelable").asType();

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/ModifierHelper.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/ModifierHelper.java
@@ -6,7 +6,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 
 
-public class ModifierHelper {
+class ModifierHelper {
     static final int PRIVATE   = -1;
     static final int DEFAULT   = 0;
     static final int PROTECTED = 1;

--- a/autobundle/build.gradle
+++ b/autobundle/build.gradle
@@ -23,6 +23,7 @@ android {
 dependencies {
     compile project(':autobundle-annotations')
     provided project(':autobundle-dispatcher')
+    compile "com.android.support:support-annotations:${supportLibraryVersion}"
 }
 
 publish {

--- a/autobundle/src/main/java/com/yatatsu/autobundle/AutoBundle.java
+++ b/autobundle/src/main/java/com/yatatsu/autobundle/AutoBundle.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 
 /**
  * Injection helper.
@@ -21,7 +22,7 @@ public class AutoBundle {
      * assign to target fields from {@link Activity#getIntent()}
      * @param activity target activity which has {@link AutoBundleField} annotated fields.
      */
-    public static void bind(Activity activity) {
+    public static void bind(@NonNull Activity activity) {
         bind(activity, activity.getIntent());
     }
 
@@ -32,7 +33,7 @@ public class AutoBundle {
      *
      * @param target target Fragment which has {@link AutoBundleField} annotated fields.
      */
-    public static void bind(Object target) {
+    public static void bind(@NonNull Object target) {
         try {
             dispatcher.bind(target);
         } catch (Exception e) {
@@ -51,7 +52,7 @@ public class AutoBundle {
      * @param target target which has {@link AutoBundleField} annotated fields.
      * @param args source bundle.
      */
-    public static void bind(Object target, Bundle args) {
+    public static void bind(@NonNull Object target, @NonNull Bundle args) {
         try {
             dispatcher.bind(target, args);
         } catch (Exception e) {
@@ -69,7 +70,7 @@ public class AutoBundle {
      * @param target target which has {@link AutoBundleField} annotated fields.
      * @param intent source bundle.
      */
-    public static void bind(Object target, Intent intent) {
+    public static void bind(@NonNull Object target, @NonNull Intent intent) {
         try {
             dispatcher.bind(target, intent);
         } catch (Exception e) {
@@ -88,7 +89,7 @@ public class AutoBundle {
      * @param source source instance which has {@link AutoBundleField} annotated fields.
      * @param args target bundle.
      */
-    public static void pack(Object source, Bundle args) {
+    public static void pack(@NonNull Object source, @NonNull Bundle args) {
         try {
             dispatcher.pack(source, args);
         } catch (Exception e) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,8 @@ buildscript {
 
 ext {
     sdkVersion = 25
-    buildToolsVersion = '25.0.1'
+    buildToolsVersion = '25.0.2'
+    supportLibraryVersion = '25.1.0'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,18 @@
 
 apply from: project.file('metadata.gradle')
 
+final androidSdkPath = System.getenv('ANDROID_HOME') ?: {
+    final localProp = new Properties()
+    try {
+        localProp.load(new FileInputStream("${rootProject.projectDir}/local.properties"))
+    } catch (IOException ignore) {}
+    localProp['sdk.dir'] ?: {
+        throw new RuntimeException("Android sdk not found")
+    }()
+}()
+
+final m2Repository = "${androidSdkPath}/extras/android/m2repository"
+
 buildscript {
     repositories {
         jcenter()
@@ -13,6 +25,7 @@ buildscript {
 }
 
 ext {
+    androidJar = fileTree(dir: "${androidSdkPath}/platforms/android-25/", include:  "android.jar")
     sdkVersion = 25
     buildToolsVersion = '25.0.2'
     supportLibraryVersion = '25.1.0'
@@ -20,6 +33,9 @@ ext {
 
 allprojects {
     repositories {
+        maven {
+            url m2Repository
+        }
         jcenter()
     }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.yatatsu.autobundle.example"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -24,8 +24,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:design:25.1.0'
+    compile "com.android.support:support-v4:${supportLibraryVersion}"
+    compile "com.android.support:support-annotations:${supportLibraryVersion}"
+    compile "com.android.support:appcompat-v7:${supportLibraryVersion}"
+    compile "com.android.support:design:${supportLibraryVersion}"
 
     compile project(':autobundle')
     annotationProcessor project(':autobundle-processor')

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/AutoBundleBindingDispatcher.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/AutoBundleBindingDispatcher.java
@@ -2,6 +2,7 @@ package com.yatatsu.autobundle;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import com.yatatsu.autobundle.example.ExampleActivity;
 import com.yatatsu.autobundle.example.ExampleActivityAutoBundle;
 import com.yatatsu.autobundle.example.ExampleBroadcastReceiver;
@@ -13,7 +14,7 @@ import com.yatatsu.autobundle.example.ExampleIntentServiceAutoBundle;
 import java.lang.Object;
 
 public final class AutoBundleBindingDispatcher {
-  public void bind(Object target, Bundle args) {
+  public void bind(@NonNull Object target, @NonNull Bundle args) {
     if (target instanceof ExampleActivity) {
       ExampleActivityAutoBundle.bind((ExampleActivity)target, args);
       return;
@@ -32,7 +33,7 @@ public final class AutoBundleBindingDispatcher {
     }
   }
 
-  public void bind(Object target, Intent intent) {
+  public void bind(@NonNull Object target, @NonNull Intent intent) {
     if (target instanceof ExampleActivity) {
       ExampleActivityAutoBundle.bind((ExampleActivity)target, intent);
       return;
@@ -47,14 +48,14 @@ public final class AutoBundleBindingDispatcher {
     }
   }
 
-  public void bind(Object target) {
+  public void bind(@NonNull Object target) {
     if (target instanceof ExampleFragment) {
       ExampleFragmentAutoBundle.bind((ExampleFragment)target);
       return;
     }
   }
 
-  public void pack(Object target, Bundle args) {
+  public void pack(@NonNull Object target, @NonNull Bundle args) {
     if (target instanceof ExampleActivity) {
       ExampleActivityAutoBundle.pack((ExampleActivity)target, args);
       return;

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/AutoBundleBindingDispatcher.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/AutoBundleBindingDispatcher.java
@@ -11,6 +11,8 @@ import com.yatatsu.autobundle.example.ExampleFragment;
 import com.yatatsu.autobundle.example.ExampleFragmentAutoBundle;
 import com.yatatsu.autobundle.example.ExampleIntentService;
 import com.yatatsu.autobundle.example.ExampleIntentServiceAutoBundle;
+import com.yatatsu.autobundle.example.NullableExampleActivity;
+import com.yatatsu.autobundle.example.NullableExampleActivityAutoBundle;
 import java.lang.Object;
 
 public final class AutoBundleBindingDispatcher {
@@ -31,6 +33,10 @@ public final class AutoBundleBindingDispatcher {
       ExampleIntentServiceAutoBundle.bind((ExampleIntentService)target, args);
       return;
     }
+    if (target instanceof NullableExampleActivity) {
+      NullableExampleActivityAutoBundle.bind((NullableExampleActivity)target, args);
+      return;
+    }
   }
 
   public void bind(@NonNull Object target, @NonNull Intent intent) {
@@ -44,6 +50,10 @@ public final class AutoBundleBindingDispatcher {
     }
     if (target instanceof ExampleIntentService) {
       ExampleIntentServiceAutoBundle.bind((ExampleIntentService)target, intent);
+      return;
+    }
+    if (target instanceof NullableExampleActivity) {
+      NullableExampleActivityAutoBundle.bind((NullableExampleActivity)target, intent);
       return;
     }
   }
@@ -70,6 +80,10 @@ public final class AutoBundleBindingDispatcher {
     }
     if (target instanceof ExampleIntentService) {
       ExampleIntentServiceAutoBundle.pack((ExampleIntentService)target, args);
+      return;
+    }
+    if (target instanceof NullableExampleActivity) {
+      NullableExampleActivityAutoBundle.pack((NullableExampleActivity)target, args);
       return;
     }
   }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleActivityAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleActivityAutoBundle.java
@@ -3,6 +3,8 @@ package com.yatatsu.autobundle.example;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import java.lang.Boolean;
 import java.lang.CharSequence;
 import java.lang.Integer;
@@ -10,18 +12,18 @@ import java.lang.String;
 import java.util.ArrayList;
 
 public final class ExampleActivityAutoBundle {
-  public static ExampleActivityAutoBundle.IntentBuilder createIntentBuilder(@ExampleActivity.IntType int type2,
-      String name) {
-    return new ExampleActivityAutoBundle.IntentBuilder(type2,name);
+  public static @NonNull ExampleActivityAutoBundle.IntentBuilder createIntentBuilder(@ExampleActivity.IntType int type2,
+      @NonNull String name) {
+    return new ExampleActivityAutoBundle.IntentBuilder(type2, name);
   }
 
-  public static void bind(ExampleActivity target, Intent intent) {
+  public static void bind(@NonNull ExampleActivity target, @NonNull Intent intent) {
     if (intent.getExtras() != null) {
       bind(target, intent.getExtras());
     }
   }
 
-  public static void bind(ExampleActivity target, Bundle source) {
+  public static void bind(@NonNull ExampleActivity target, @NonNull Bundle source) {
     if (source.containsKey("type2")) {
       target.type2 = (int) source.getInt("type2");
     } else {
@@ -58,9 +60,12 @@ public final class ExampleActivityAutoBundle {
     if (source.containsKey("booleanField")) {
       target.booleanField = (Boolean) source.getBoolean("booleanField");
     }
+    if (source.containsKey("intOption")) {
+      target.intOption = (int) source.getInt("intOption");
+    }
   }
 
-  public static void pack(ExampleActivity source, Bundle args) {
+  public static void pack(@NonNull ExampleActivity source, @NonNull Bundle args) {
     args.putInt("type2", source.type2);
     if (source.getName() != null) {
       args.putString("name", source.getName());
@@ -91,37 +96,38 @@ public final class ExampleActivityAutoBundle {
     if (source.booleanField != null) {
       args.putBoolean("booleanField", source.booleanField);
     }
+    args.putInt("intOption", source.intOption);
   }
 
   public static final class IntentBuilder {
     final Bundle args;
 
-    public IntentBuilder(@ExampleActivity.IntType int type2, String name) {
+    public IntentBuilder(@ExampleActivity.IntType int type2, @NonNull String name) {
       this.args = new Bundle();
       this.args.putInt("type2", type2);
       this.args.putString("name", name);
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder type1(@ExampleActivity.IntType int type1) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder type1(@ExampleActivity.IntType int type1) {
       args.putInt("type1", type1);
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder optionalName(String optionalName) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder optionalName(@Nullable String optionalName) {
       if (optionalName != null) {
         args.putString("optionalName", optionalName);
       }
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder fooList(ArrayList<CharSequence> fooList) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder fooList(@Nullable ArrayList<CharSequence> fooList) {
       if (fooList != null) {
         args.putCharSequenceArrayList("fooList", fooList);
       }
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder exampleData(ExampleData exampleData) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder exampleData(@Nullable ExampleData exampleData) {
       if (exampleData != null) {
         ParcelableConverter exampleDataConverter = new ParcelableConverter();
         args.putParcelable("exampleData", exampleDataConverter.convert(exampleData) );
@@ -129,14 +135,14 @@ public final class ExampleActivityAutoBundle {
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder persons(ArrayList<Person> persons) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder persons(@Nullable ArrayList<Person> persons) {
       if (persons != null) {
         args.putParcelableArrayList("persons", persons);
       }
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder exampleData2(ExampleData exampleData2) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder exampleData2(@Nullable ExampleData exampleData2) {
       if (exampleData2 != null) {
         ParcelableConverter exampleData2Converter = new ParcelableConverter();
         args.putParcelable("exampleData2", exampleData2Converter.convert(exampleData2) );
@@ -144,27 +150,32 @@ public final class ExampleActivityAutoBundle {
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder integerField(Integer integerField) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder integerField(@Nullable Integer integerField) {
       if (integerField != null) {
         args.putInt("integerField", integerField);
       }
       return this;
     }
 
-    public ExampleActivityAutoBundle.IntentBuilder booleanField(Boolean booleanField) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder booleanField(@Nullable Boolean booleanField) {
       if (booleanField != null) {
         args.putBoolean("booleanField", booleanField);
       }
       return this;
     }
 
-    public Intent build(Context context) {
+    public @NonNull ExampleActivityAutoBundle.IntentBuilder intOption(int intOption) {
+      args.putInt("intOption", intOption);
+      return this;
+    }
+
+    public @NonNull Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, ExampleActivity.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public Intent build(Intent intent) {
+    public @NonNull Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleActivityAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleActivityAutoBundle.java
@@ -3,7 +3,9 @@ package com.yatatsu.autobundle.example;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import java.lang.Boolean;
 import java.lang.CharSequence;
+import java.lang.Integer;
 import java.lang.String;
 import java.util.ArrayList;
 
@@ -50,6 +52,12 @@ public final class ExampleActivityAutoBundle {
       ParcelableConverter exampleData2Converter = new ParcelableConverter();
       target.setExampleData2( (ExampleData) exampleData2Converter.original( source.getParcelable("exampleData2") ) );
     }
+    if (source.containsKey("integerField")) {
+      target.integerField = (Integer) source.getInt("integerField");
+    }
+    if (source.containsKey("booleanField")) {
+      target.booleanField = (Boolean) source.getBoolean("booleanField");
+    }
   }
 
   public static void pack(ExampleActivity source, Bundle args) {
@@ -76,6 +84,12 @@ public final class ExampleActivityAutoBundle {
     if (source.getExampleData2() != null) {
       ParcelableConverter exampleData2Converter = new ParcelableConverter();
       args.putParcelable("exampleData2", exampleData2Converter.convert(source.getExampleData2()) );
+    }
+    if (source.integerField != null) {
+      args.putInt("integerField", source.integerField);
+    }
+    if (source.booleanField != null) {
+      args.putBoolean("booleanField", source.booleanField);
     }
   }
 
@@ -126,6 +140,20 @@ public final class ExampleActivityAutoBundle {
       if (exampleData2 != null) {
         ParcelableConverter exampleData2Converter = new ParcelableConverter();
         args.putParcelable("exampleData2", exampleData2Converter.convert(exampleData2) );
+      }
+      return this;
+    }
+
+    public ExampleActivityAutoBundle.IntentBuilder integerField(Integer integerField) {
+      if (integerField != null) {
+        args.putInt("integerField", integerField);
+      }
+      return this;
+    }
+
+    public ExampleActivityAutoBundle.IntentBuilder booleanField(Boolean booleanField) {
+      if (booleanField != null) {
+        args.putBoolean("booleanField", booleanField);
       }
       return this;
     }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleBroadcastReceiverAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleBroadcastReceiverAutoBundle.java
@@ -3,20 +3,21 @@ package com.yatatsu.autobundle.example;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import java.lang.String;
 
 public final class ExampleBroadcastReceiverAutoBundle {
-  public static ExampleBroadcastReceiverAutoBundle.IntentBuilder createIntentBuilder(String message) {
+  public static @NonNull ExampleBroadcastReceiverAutoBundle.IntentBuilder createIntentBuilder(@NonNull String message) {
     return new ExampleBroadcastReceiverAutoBundle.IntentBuilder(message);
   }
 
-  public static void bind(ExampleBroadcastReceiver target, Intent intent) {
+  public static void bind(@NonNull ExampleBroadcastReceiver target, @NonNull Intent intent) {
     if (intent.getExtras() != null) {
       bind(target, intent.getExtras());
     }
   }
 
-  public static void bind(ExampleBroadcastReceiver target, Bundle source) {
+  public static void bind(@NonNull ExampleBroadcastReceiver target, @NonNull Bundle source) {
     if (source.containsKey("message")) {
       target.message = (String) source.getString("message");
     } else {
@@ -24,7 +25,7 @@ public final class ExampleBroadcastReceiverAutoBundle {
     }
   }
 
-  public static void pack(ExampleBroadcastReceiver source, Bundle args) {
+  public static void pack(@NonNull ExampleBroadcastReceiver source, @NonNull Bundle args) {
     if (source.message != null) {
       args.putString("message", source.message);
     } else {
@@ -35,18 +36,18 @@ public final class ExampleBroadcastReceiverAutoBundle {
   public static final class IntentBuilder {
     final Bundle args;
 
-    public IntentBuilder(String message) {
+    public IntentBuilder(@NonNull String message) {
       this.args = new Bundle();
       this.args.putString("message", message);
     }
 
-    public Intent build(Context context) {
+    public @NonNull Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, ExampleBroadcastReceiver.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public Intent build(Intent intent) {
+    public @NonNull Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleFragmentAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleFragmentAutoBundle.java
@@ -1,20 +1,23 @@
 package com.yatatsu.autobundle.example;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import java.lang.String;
 import java.util.Date;
 
 public final class ExampleFragmentAutoBundle {
-  public static ExampleFragmentAutoBundle.FragmentBuilder createFragmentBuilder(String title,
-      Date targetDate) {
-    return new ExampleFragmentAutoBundle.FragmentBuilder(title,targetDate);
+  public static @NonNull ExampleFragmentAutoBundle.FragmentBuilder createFragmentBuilder(@NonNull String title,
+      @NonNull Date targetDate) {
+    return new ExampleFragmentAutoBundle.FragmentBuilder(title, targetDate);
   }
 
-  public static void bind(ExampleFragment target) {
-    bind(target, target.getArguments());
+  public static void bind(@NonNull ExampleFragment target) {
+    if (target.getArguments() != null) {
+      bind(target, target.getArguments());
+    }
   }
 
-  public static void bind(ExampleFragment target, Bundle source) {
+  public static void bind(@NonNull ExampleFragment target, @NonNull Bundle source) {
     if (source.containsKey("title")) {
       target.title = (String) source.getString("title");
     } else {
@@ -28,7 +31,7 @@ public final class ExampleFragmentAutoBundle {
     }
   }
 
-  public static void pack(ExampleFragment source, Bundle args) {
+  public static void pack(@NonNull ExampleFragment source, @NonNull Bundle args) {
     if (source.title != null) {
       args.putString("title", source.title);
     } else {
@@ -45,20 +48,20 @@ public final class ExampleFragmentAutoBundle {
   public static final class FragmentBuilder {
     final Bundle args;
 
-    public FragmentBuilder(String title, Date targetDate) {
+    public FragmentBuilder(@NonNull String title, @NonNull Date targetDate) {
       this.args = new Bundle();
       this.args.putString("title", title);
       ExampleFragment.DateArgConverter targetDateConverter = new ExampleFragment.DateArgConverter();
       this.args.putLong("targetDate", targetDateConverter.convert(targetDate) );
     }
 
-    public ExampleFragment build() {
+    public @NonNull ExampleFragment build() {
       ExampleFragment fragment = new ExampleFragment();
       fragment.setArguments(args);
       return fragment;
     }
 
-    public ExampleFragment build(ExampleFragment fragment) {
+    public @NonNull ExampleFragment build(@NonNull ExampleFragment fragment) {
       fragment.setArguments(args);
       return fragment;
     }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleIntentServiceAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleIntentServiceAutoBundle.java
@@ -3,20 +3,21 @@ package com.yatatsu.autobundle.example;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import java.lang.String;
 
 public final class ExampleIntentServiceAutoBundle {
-  public static ExampleIntentServiceAutoBundle.IntentBuilder createIntentBuilder(String message) {
+  public static @NonNull ExampleIntentServiceAutoBundle.IntentBuilder createIntentBuilder(@NonNull String message) {
     return new ExampleIntentServiceAutoBundle.IntentBuilder(message);
   }
 
-  public static void bind(ExampleIntentService target, Intent intent) {
+  public static void bind(@NonNull ExampleIntentService target, @NonNull Intent intent) {
     if (intent.getExtras() != null) {
       bind(target, intent.getExtras());
     }
   }
 
-  public static void bind(ExampleIntentService target, Bundle source) {
+  public static void bind(@NonNull ExampleIntentService target, @NonNull Bundle source) {
     if (source.containsKey("message")) {
       target.string = (String) source.getString("message");
     } else {
@@ -24,7 +25,7 @@ public final class ExampleIntentServiceAutoBundle {
     }
   }
 
-  public static void pack(ExampleIntentService source, Bundle args) {
+  public static void pack(@NonNull ExampleIntentService source, @NonNull Bundle args) {
     if (source.string != null) {
       args.putString("message", source.string);
     } else {
@@ -35,18 +36,18 @@ public final class ExampleIntentServiceAutoBundle {
   public static final class IntentBuilder {
     final Bundle args;
 
-    public IntentBuilder(String message) {
+    public IntentBuilder(@NonNull String message) {
       this.args = new Bundle();
       this.args.putString("message", message);
     }
 
-    public Intent build(Context context) {
+    public @NonNull Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, ExampleIntentService.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public Intent build(Intent intent) {
+    public @NonNull Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/NullableExampleActivityAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/NullableExampleActivityAutoBundle.java
@@ -1,0 +1,72 @@
+package com.yatatsu.autobundle.example;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import java.lang.Integer;
+import java.lang.String;
+
+public final class NullableExampleActivityAutoBundle {
+  public static @NonNull NullableExampleActivityAutoBundle.IntentBuilder createIntentBuilder() {
+    return new NullableExampleActivityAutoBundle.IntentBuilder();
+  }
+
+  public static void bind(@NonNull NullableExampleActivity target, @NonNull Intent intent) {
+    if (intent.getExtras() != null) {
+      bind(target, intent.getExtras());
+    }
+  }
+
+  public static void bind(@NonNull NullableExampleActivity target, @NonNull Bundle source) {
+    if (source.containsKey("name")) {
+      target.name = (String) source.getString("name");
+    }
+    if (source.containsKey("number")) {
+      target.number = (Integer) source.getInt("number");
+    }
+  }
+
+  public static void pack(@NonNull NullableExampleActivity source, @NonNull Bundle args) {
+    if (source.name != null) {
+      args.putString("name", source.name);
+    }
+    if (source.number != null) {
+      args.putInt("number", source.number);
+    }
+  }
+
+  public static final class IntentBuilder {
+    final Bundle args;
+
+    public IntentBuilder() {
+      this.args = new Bundle();
+    }
+
+    public @NonNull NullableExampleActivityAutoBundle.IntentBuilder name(@Nullable String name) {
+      if (name != null) {
+        args.putString("name", name);
+      }
+      return this;
+    }
+
+    public @NonNull NullableExampleActivityAutoBundle.IntentBuilder number(@Nullable Integer number) {
+      if (number != null) {
+        args.putInt("number", number);
+      }
+      return this;
+    }
+
+    public @NonNull Intent build(@NonNull Context context) {
+      Intent intent = new Intent(context, NullableExampleActivity.class);
+      intent.putExtras(args);
+      return intent;
+    }
+
+    public @NonNull Intent build(@NonNull Intent intent) {
+      intent.putExtras(args);
+      return intent;
+    }
+  }
+}

--- a/example/src/main/java/com/yatatsu/autobundle/example/ExampleActivity.java
+++ b/example/src/main/java/com/yatatsu/autobundle/example/ExampleActivity.java
@@ -50,6 +50,12 @@ public class ExampleActivity extends AppCompatActivity {
     @AutoBundleField(required = false, converter = ParcelableConverter.class)
     ExampleData exampleData2;
 
+    @AutoBundleField(required = false)
+    Integer integerField;
+
+    @AutoBundleField(required = false)
+    Boolean booleanField;
+
     String getName() {
         return name;
     }

--- a/example/src/main/java/com/yatatsu/autobundle/example/ExampleActivity.java
+++ b/example/src/main/java/com/yatatsu/autobundle/example/ExampleActivity.java
@@ -56,6 +56,9 @@ public class ExampleActivity extends AppCompatActivity {
     @AutoBundleField(required = false)
     Boolean booleanField;
 
+    @AutoBundleField(required = false)
+    int intOption;
+
     String getName() {
         return name;
     }

--- a/example/src/main/java/com/yatatsu/autobundle/example/NullableExampleActivity.java
+++ b/example/src/main/java/com/yatatsu/autobundle/example/NullableExampleActivity.java
@@ -1,0 +1,18 @@
+package com.yatatsu.autobundle.example;
+
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import com.yatatsu.autobundle.AutoBundleField;
+
+/**
+ * Example for @Nullable
+ */
+public class NullableExampleActivity extends AppCompatActivity {
+
+    @Nullable @AutoBundleField
+    String name;
+
+    @Nullable @AutoBundleField
+    Integer number;
+}


### PR DESCRIPTION
# `@Nullable` and `@NonNull` support

It will make clearly nullability. Especially in Kotlin.

### Builder method with annotations.

In Builder, parameter of constructor is for field with `@AutoBundleField`, which expects as required, and parameter has `@NonNull` annotation.
And not required field has `@Nullable` annotation.

```java
public class MyActivity extends Activity {
    @AutoBundleField String name;
    @AutoBundleField(required=false) String nickName;
}

// here is generated builder
public final class MyActivityAutoBundle {

public static final class IntentBuilder {
    final Bundle args;

    public IntentBuilder(@NonNull String name) {
      this.args = new Bundle();
      this.args.putString("name", name);
    }

    public @NonNull MyActivityAutoBundle.IntentBuilder nickName(@Nullable String nickName) {
      if (nickName != null) {
        args.putString("nickName", nickName);
      }
      return this;
    }

    public @NonNull Intent build(@NonNull Context context) {
      Intent intent = new Intent(context, ExampleActivity.class);
      intent.putExtras(args);
      return intent;
    }

    public @NonNull Intent build(@NonNull Intent intent) {
      intent.putExtras(args);
      return intent;
    }
}
}
```

### `@Nullable` makes `required=false`

`@Nullable` field will be not required. 

Any annotation named `Nullable` will be ok. 
(`javax.annotation`, `android.support.annotation` or any)

```java
public class MyActivity extends Activity {

    // it equals to @AutoBundleField(required=false)
    @Nullable @AutoBundleField
    String name;

    @Nullable @AutoBundleField
    Integer number;
}
```

### NOTE

It brings new dependency with android support annotation library.

