### PR TITLE
Define method annotation spec with `addAnnotation()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,27 @@ public final class MyActivityAutoBundle {
       this.args.putInt("exampleId", exampleId);
     }
 
-    public @NonNull MyActivityAutoBundle.Builder optionalId(int optionalId) {
+    @NonNull
+    public MyActivityAutoBundle.Builder optionalId(int optionalId) {
       args.putInt("optionalId", optionalId);
       return this;
     }
 
-    public @NonNull Intent build(@NonNull Context context) {
+    @NonNull
+    public Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, MyActivity.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Intent build(@NonNull Intent intent) {
+    @NonNull
+    public Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }

--- a/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleWriter.java
+++ b/autobundle-processor/src/main/java/com/yatatsu/autobundle/processor/AutoBundleWriter.java
@@ -63,7 +63,8 @@ class AutoBundleWriter {
         MethodSpec.Builder builder =
                 MethodSpec.methodBuilder("builder")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(builderClass.annotated(ANNOTATION_NONNULL))
+                .addAnnotation(ANNOTATION_NONNULL)
+                .returns(builderClass)
                 .addCode("return new $T(", builderClass);
         for (int i = 0, count = target.getRequiredArgs().size(); i < count; i++) {
             AutoBundleBindingField arg = target.getRequiredArgs().get(i);
@@ -157,7 +158,8 @@ class AutoBundleWriter {
             MethodSpec.Builder builder = MethodSpec.methodBuilder(argKey)
                     .addModifiers(Modifier.PUBLIC)
                     .addParameter(paramBuilder.build())
-                    .returns(getBuilderClassName(target).annotated(ANNOTATION_NONNULL));
+                    .addAnnotation(ANNOTATION_NONNULL)
+                    .returns(getBuilderClassName(target));
 
             if (nullable) {
                 builder.beginControlFlow("if ($N != null)", argKey);
@@ -198,7 +200,8 @@ class AutoBundleWriter {
         ClassName targetClass = target.getTargetType();
         MethodSpec buildWithNoParam = MethodSpec.methodBuilder("build")
                 .addModifiers(Modifier.PUBLIC)
-                .returns(targetClass.annotated(ANNOTATION_NONNULL))
+                .addAnnotation(ANNOTATION_NONNULL)
+                .returns(targetClass)
                 .addStatement("$T fragment = new $T()", targetClass, targetClass)
                 .addStatement("fragment.setArguments($N)", fieldName)
                 .addStatement("return fragment")
@@ -207,7 +210,8 @@ class AutoBundleWriter {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ParameterSpec.builder(targetClass, "fragment")
                         .addAnnotation(ANNOTATION_NONNULL).build())
-                .returns(targetClass.annotated(ANNOTATION_NONNULL))
+                .addAnnotation(ANNOTATION_NONNULL)
+                .returns(targetClass)
                 .addStatement("fragment.setArguments($N)", fieldName)
                 .addStatement("return fragment")
                 .build();
@@ -223,7 +227,8 @@ class AutoBundleWriter {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ParameterSpec.builder(CLASS_CONTEXT, "context")
                         .addAnnotation(ANNOTATION_NONNULL).build())
-                .returns(CLASS_INTENT.annotated(ANNOTATION_NONNULL))
+                .addAnnotation(ANNOTATION_NONNULL)
+                .returns(CLASS_INTENT)
                 .addStatement("$T intent = new $T(context, $T.class)",
                         CLASS_INTENT, CLASS_INTENT, target.getTargetType())
                 .addStatement("intent.putExtras($N)", fieldName)
@@ -233,7 +238,8 @@ class AutoBundleWriter {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ParameterSpec.builder(CLASS_INTENT, "intent")
                         .addAnnotation(ANNOTATION_NONNULL).build())
-                .returns(CLASS_INTENT.annotated(ANNOTATION_NONNULL))
+                .addAnnotation(ANNOTATION_NONNULL)
+                .returns(CLASS_INTENT)
                 .addStatement("intent.putExtras($N)", fieldName)
                 .addStatement("return intent")
                 .build();
@@ -245,7 +251,8 @@ class AutoBundleWriter {
     private static MethodSpec createBuildBundleMethod(String fieldName) {
         return MethodSpec.methodBuilder("bundle")
                 .addModifiers(Modifier.PUBLIC)
-                .returns(CLASS_BUNDLE.annotated(ANNOTATION_NONNULL))
+                .addAnnotation(ANNOTATION_NONNULL)
+                .returns(CLASS_BUNDLE)
                 .addStatement("return $N", fieldName)
                 .build();
     }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleActivityAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleActivityAutoBundle.java
@@ -12,7 +12,8 @@ import java.lang.String;
 import java.util.ArrayList;
 
 public final class ExampleActivityAutoBundle {
-  public static @NonNull ExampleActivityAutoBundle.Builder builder(@ExampleActivity.IntType int type2,
+  @NonNull
+  public static ExampleActivityAutoBundle.Builder builder(@ExampleActivity.IntType int type2,
       @NonNull String name) {
     return new ExampleActivityAutoBundle.Builder(type2, name);
   }
@@ -108,26 +109,30 @@ public final class ExampleActivityAutoBundle {
       this.args.putString("name", name);
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder type1(@ExampleActivity.IntType int type1) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder type1(@ExampleActivity.IntType int type1) {
       args.putInt("type1", type1);
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder optionalName(@Nullable String optionalName) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder optionalName(@Nullable String optionalName) {
       if (optionalName != null) {
         args.putString("optionalName", optionalName);
       }
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder fooList(@Nullable ArrayList<CharSequence> fooList) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder fooList(@Nullable ArrayList<CharSequence> fooList) {
       if (fooList != null) {
         args.putCharSequenceArrayList("fooList", fooList);
       }
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder exampleData(@Nullable ExampleData exampleData) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder exampleData(@Nullable ExampleData exampleData) {
       if (exampleData != null) {
         ParcelableConverter exampleDataConverter = new ParcelableConverter();
         args.putParcelable("exampleData", exampleDataConverter.convert(exampleData) );
@@ -135,14 +140,16 @@ public final class ExampleActivityAutoBundle {
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder persons(@Nullable ArrayList<Person> persons) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder persons(@Nullable ArrayList<Person> persons) {
       if (persons != null) {
         args.putParcelableArrayList("persons", persons);
       }
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder exampleData2(@Nullable ExampleData exampleData2) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder exampleData2(@Nullable ExampleData exampleData2) {
       if (exampleData2 != null) {
         ParcelableConverter exampleData2Converter = new ParcelableConverter();
         args.putParcelable("exampleData2", exampleData2Converter.convert(exampleData2) );
@@ -150,37 +157,43 @@ public final class ExampleActivityAutoBundle {
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder integerField(@Nullable Integer integerField) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder integerField(@Nullable Integer integerField) {
       if (integerField != null) {
         args.putInt("integerField", integerField);
       }
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder booleanField(@Nullable Boolean booleanField) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder booleanField(@Nullable Boolean booleanField) {
       if (booleanField != null) {
         args.putBoolean("booleanField", booleanField);
       }
       return this;
     }
 
-    public @NonNull ExampleActivityAutoBundle.Builder intOption(int intOption) {
+    @NonNull
+    public ExampleActivityAutoBundle.Builder intOption(int intOption) {
       args.putInt("intOption", intOption);
       return this;
     }
 
-    public @NonNull Intent build(@NonNull Context context) {
+    @NonNull
+    public Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, ExampleActivity.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Intent build(@NonNull Intent intent) {
+    @NonNull
+    public Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleBroadcastReceiverAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleBroadcastReceiverAutoBundle.java
@@ -7,7 +7,8 @@ import android.support.annotation.NonNull;
 import java.lang.String;
 
 public final class ExampleBroadcastReceiverAutoBundle {
-  public static @NonNull ExampleBroadcastReceiverAutoBundle.Builder builder(@NonNull String message) {
+  @NonNull
+  public static ExampleBroadcastReceiverAutoBundle.Builder builder(@NonNull String message) {
     return new ExampleBroadcastReceiverAutoBundle.Builder(message);
   }
 
@@ -41,18 +42,21 @@ public final class ExampleBroadcastReceiverAutoBundle {
       this.args.putString("message", message);
     }
 
-    public @NonNull Intent build(@NonNull Context context) {
+    @NonNull
+    public Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, ExampleBroadcastReceiver.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Intent build(@NonNull Intent intent) {
+    @NonNull
+    public Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleBundleDelegateAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleBundleDelegateAutoBundle.java
@@ -7,7 +7,8 @@ import java.lang.String;
 import java.util.ArrayList;
 
 public final class ExampleBundleDelegateAutoBundle {
-  public static @NonNull ExampleBundleDelegateAutoBundle.Builder builder(@NonNull String name) {
+  @NonNull
+  public static ExampleBundleDelegateAutoBundle.Builder builder(@NonNull String name) {
     return new ExampleBundleDelegateAutoBundle.Builder(name);
   }
 
@@ -45,19 +46,22 @@ public final class ExampleBundleDelegateAutoBundle {
       this.args.putString("name", name);
     }
 
-    public @NonNull ExampleBundleDelegateAutoBundle.Builder number(int number) {
+    @NonNull
+    public ExampleBundleDelegateAutoBundle.Builder number(int number) {
       args.putInt("number", number);
       return this;
     }
 
-    public @NonNull ExampleBundleDelegateAutoBundle.Builder list(@Nullable ArrayList<String> list) {
+    @NonNull
+    public ExampleBundleDelegateAutoBundle.Builder list(@Nullable ArrayList<String> list) {
       if (list != null) {
         args.putStringArrayList("list", list);
       }
       return this;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleFragmentAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleFragmentAutoBundle.java
@@ -6,7 +6,8 @@ import java.lang.String;
 import java.util.Date;
 
 public final class ExampleFragmentAutoBundle {
-  public static @NonNull ExampleFragmentAutoBundle.Builder builder(@NonNull String title,
+  @NonNull
+  public static ExampleFragmentAutoBundle.Builder builder(@NonNull String title,
       @NonNull Date targetDate) {
     return new ExampleFragmentAutoBundle.Builder(title, targetDate);
   }
@@ -55,18 +56,21 @@ public final class ExampleFragmentAutoBundle {
       this.args.putLong("targetDate", targetDateConverter.convert(targetDate) );
     }
 
-    public @NonNull ExampleFragment build() {
+    @NonNull
+    public ExampleFragment build() {
       ExampleFragment fragment = new ExampleFragment();
       fragment.setArguments(args);
       return fragment;
     }
 
-    public @NonNull ExampleFragment build(@NonNull ExampleFragment fragment) {
+    @NonNull
+    public ExampleFragment build(@NonNull ExampleFragment fragment) {
       fragment.setArguments(args);
       return fragment;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleIntentServiceAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/ExampleIntentServiceAutoBundle.java
@@ -7,7 +7,8 @@ import android.support.annotation.NonNull;
 import java.lang.String;
 
 public final class ExampleIntentServiceAutoBundle {
-  public static @NonNull ExampleIntentServiceAutoBundle.Builder builder(@NonNull String message) {
+  @NonNull
+  public static ExampleIntentServiceAutoBundle.Builder builder(@NonNull String message) {
     return new ExampleIntentServiceAutoBundle.Builder(message);
   }
 
@@ -41,18 +42,21 @@ public final class ExampleIntentServiceAutoBundle {
       this.args.putString("message", message);
     }
 
-    public @NonNull Intent build(@NonNull Context context) {
+    @NonNull
+    public Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, ExampleIntentService.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Intent build(@NonNull Intent intent) {
+    @NonNull
+    public Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }

--- a/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/NullableExampleActivityAutoBundle.java
+++ b/example/build/generated/source/apt/debug/com/yatatsu/autobundle/example/NullableExampleActivityAutoBundle.java
@@ -9,7 +9,8 @@ import java.lang.Integer;
 import java.lang.String;
 
 public final class NullableExampleActivityAutoBundle {
-  public static @NonNull NullableExampleActivityAutoBundle.Builder builder() {
+  @NonNull
+  public static NullableExampleActivityAutoBundle.Builder builder() {
     return new NullableExampleActivityAutoBundle.Builder();
   }
 
@@ -44,32 +45,37 @@ public final class NullableExampleActivityAutoBundle {
       this.args = new Bundle();
     }
 
-    public @NonNull NullableExampleActivityAutoBundle.Builder name(@Nullable String name) {
+    @NonNull
+    public NullableExampleActivityAutoBundle.Builder name(@Nullable String name) {
       if (name != null) {
         args.putString("name", name);
       }
       return this;
     }
 
-    public @NonNull NullableExampleActivityAutoBundle.Builder number(@Nullable Integer number) {
+    @NonNull
+    public NullableExampleActivityAutoBundle.Builder number(@Nullable Integer number) {
       if (number != null) {
         args.putInt("number", number);
       }
       return this;
     }
 
-    public @NonNull Intent build(@NonNull Context context) {
+    @NonNull
+    public Intent build(@NonNull Context context) {
       Intent intent = new Intent(context, NullableExampleActivity.class);
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Intent build(@NonNull Intent intent) {
+    @NonNull
+    public Intent build(@NonNull Intent intent) {
       intent.putExtras(args);
       return intent;
     }
 
-    public @NonNull Bundle bundle() {
+    @NonNull
+    public Bundle bundle() {
       return args;
     }
   }


### PR DESCRIPTION
I want to change method spec defining.

AutoBundleWriter generates some methods with annotation. Unfortunately my project depends on newer JavaPoet version (1.11.0) generates invalid code:

```java
public final class LibraryFragmentAutoBundle {
  public static LibraryFragmentAutoBundle. @NonNull Builder builder() {
    return new LibraryFragmentAutoBundle.Builder();
  }
  ...
```

JavaPoet contains braking changes for AutoBundle but I want to use it. For fixing this, it might be better to change method spec defining.

AutoBundleWriter defines some methods as `.returns(fooClass.annotated(ANNOTATION_NONNULL))` now. It seems that method signature means "returns annotated Foo class type":

```java
private static MethodSpec createCallBuilderMethod(AutoBundleBindingClass target) {
    ClassName builderClass = getBuilderClassName(target);
    MethodSpec.Builder builder =
            MethodSpec.methodBuilder("builder")
            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
            .returns(builderClass.annotated(ANNOTATION_NONNULL)) // <- method's returning signature ("annotated type")
            .addCode("return new $T(", builderClass);
...
```

So, separate annotation from returning: 

```java
private static MethodSpec createCallBuilderMethod(AutoBundleBindingClass target) {
    ClassName builderClass = getBuilderClassName(target);
    MethodSpec.Builder builder =
            MethodSpec.methodBuilder("builder")
            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
            .addAnnotation(ANNOTATION_NONNULL) // <- method's annotation
            .returns(builderClass)             // <- method's returning signature
            .addCode("return new $T(", builderClass);
...
```

then

```java
public final class LibraryFragmentAutoBundle {
  @NonNull
  public static LibraryFragmentAutoBundle.Builder builder() {
    return new LibraryFragmentAutoBundle.Builder();
  }
...
```